### PR TITLE
PU-10 adjust Serializable to php 8.1

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -111,13 +111,7 @@ class Money implements \JsonSerializable
         return (int)$value;
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'amount'   => $this->amount,


### PR DESCRIPTION
Return type of SebastianBergmann\Money\Money::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice